### PR TITLE
가장 최신의 대기 선물정보 가져오기, 유저 Entity에 getName 추가

### DIFF
--- a/smilekarina/src/main/java/com/example/smilekarina/gift/application/GiftService.java
+++ b/smilekarina/src/main/java/com/example/smilekarina/gift/application/GiftService.java
@@ -1,10 +1,14 @@
 package com.example.smilekarina.gift.application;
 
+import com.example.smilekarina.gift.dto.GiftLastDto;
 import com.example.smilekarina.gift.vo.GiftIn;
 
 public interface GiftService {
 
     // 포인트 선물하기
     void registerGift(Long userId, GiftIn giftIn);
+
+    // 포인트 선물 받기 내역 조회(가장최근 것만)
+    GiftLastDto getLastGift(String token);
 
 }

--- a/smilekarina/src/main/java/com/example/smilekarina/gift/application/GiftServiceImpl.java
+++ b/smilekarina/src/main/java/com/example/smilekarina/gift/application/GiftServiceImpl.java
@@ -3,15 +3,21 @@ package com.example.smilekarina.gift.application;
 import com.example.smilekarina.gift.domain.Gift;
 import com.example.smilekarina.gift.domain.GiftType;
 import com.example.smilekarina.gift.domain.GiftTypeConverter;
+import com.example.smilekarina.gift.dto.GiftLastDto;
 import com.example.smilekarina.gift.infrastructure.GiftRepository;
 import com.example.smilekarina.gift.vo.GiftIn;
 import com.example.smilekarina.point.application.PointService;
 import com.example.smilekarina.point.domain.PointType;
 import com.example.smilekarina.point.dto.PointAddDto;
 import com.example.smilekarina.user.application.UserService;
+import com.example.smilekarina.user.domain.User;
+import com.example.smilekarina.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
 
 @Service
@@ -22,6 +28,7 @@ public class GiftServiceImpl implements GiftService {
     private final UserService userService;
     private final PointService pointService;
     private final GiftRepository giftRepository;
+    private final UserRepository userRepository;
 
     // 포인트 선물하기
     @Override
@@ -48,8 +55,41 @@ public class GiftServiceImpl implements GiftService {
                 .imageId(giftIn.getImageId())
                 .giftSenderId(userId)
                 .giftType(giftType)
+                .point(giftIn.getPoint())
                 .senderPointId(senderPointId)
                 .build();
         giftRepository.save(gift);
     }
+
+    // 포인트 선물 받기 내역 조회(가장최근 것만)
+    @Override
+    public GiftLastDto getLastGift(String token) {
+
+        // 토큰 정보에서 userId 값 가져 오기
+        Long userId = userService.getUserIdFromToken(token);
+
+        // 선물 테이블에서 대기 중인 가장 최근 선물 정보만 가져오기
+        GiftType giftType = new GiftTypeConverter().convertToEntityAttribute(GiftType.WAIT.getCode());
+        Optional<Gift> gift= giftRepository.findFirstByGiftRecipientIdAndGiftTypeOrderByIdDesc(userId, giftType);
+
+        // 대기중인 선물 정보가 없는 경우 null을 리턴
+        if(gift.isEmpty()) {
+            return null;
+        }
+
+        Gift targetGift = gift.get();
+
+        // 보낸 유저 정보 가져오기  TODO 데이터 가지러 테이블 여러번 왔다 갔다 해도 될지 고민
+        User user = userRepository.findById(targetGift.getGiftSenderId()).orElseThrow(() -> new NoSuchElementException("User not found"));
+
+        return GiftLastDto.builder()
+                .giftId(targetGift.getId())
+                .senderLoginId(user.getLoginId())
+                .senderName(user.getName())
+                .point(targetGift.getPoint())
+                .giftMessage(targetGift.getGiftMessage())
+                .createdDate(targetGift.getCreatedDate())
+                .build();
+    }
+
 }

--- a/smilekarina/src/main/java/com/example/smilekarina/gift/domain/Gift.java
+++ b/smilekarina/src/main/java/com/example/smilekarina/gift/domain/Gift.java
@@ -34,6 +34,9 @@ public class Gift extends BaseEntity {
     @Convert(converter = GiftTypeConverter.class)
     private GiftType giftType;
 
+    @Column(nullable = false, name = "point")
+    private Integer point;
+
     @Column(nullable = false, name = "sender_point_id")
     private Long senderPointId;
 

--- a/smilekarina/src/main/java/com/example/smilekarina/gift/dto/GiftLastDto.java
+++ b/smilekarina/src/main/java/com/example/smilekarina/gift/dto/GiftLastDto.java
@@ -1,0 +1,22 @@
+package com.example.smilekarina.gift.dto;
+
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Builder
+@ToString
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GiftLastDto {
+
+    private Long giftId;
+    private String senderLoginId;
+    private String senderName;
+    private Integer point;
+    private String giftMessage;
+    private LocalDateTime createdDate;
+
+}

--- a/smilekarina/src/main/java/com/example/smilekarina/gift/infrastructure/GiftRepository.java
+++ b/smilekarina/src/main/java/com/example/smilekarina/gift/infrastructure/GiftRepository.java
@@ -1,8 +1,13 @@
 package com.example.smilekarina.gift.infrastructure;
 
 import com.example.smilekarina.gift.domain.Gift;
+import com.example.smilekarina.gift.domain.GiftType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface GiftRepository extends JpaRepository<Gift, Long> {
+
+    Optional<Gift> findFirstByGiftRecipientIdAndGiftTypeOrderByIdDesc(Long gift_recipientId, GiftType giftType);
 
 }

--- a/smilekarina/src/main/java/com/example/smilekarina/gift/presentation/GiftController.java
+++ b/smilekarina/src/main/java/com/example/smilekarina/gift/presentation/GiftController.java
@@ -1,13 +1,17 @@
 package com.example.smilekarina.gift.presentation;
 
 import com.example.smilekarina.gift.application.GiftService;
+import com.example.smilekarina.gift.dto.GiftLastDto;
 import com.example.smilekarina.gift.vo.GiftIn;
+import com.example.smilekarina.gift.vo.GiftLastOut;
 import com.example.smilekarina.global.vo.ResponseOut;
 import com.example.smilekarina.point.application.PointService;
 import com.example.smilekarina.point.dto.PointPasswordCheckDto;
 import com.example.smilekarina.user.application.UserService;
+import com.example.smilekarina.user.vo.UserGetOut;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class GiftController {
 
+    private final ModelMapper modelMapper;
     private final GiftService giftService;
     private final PointService pointService;
     private final UserService userService;
@@ -51,18 +56,22 @@ public class GiftController {
         return ResponseEntity.ok(responseOut);
     }
 
-    //******************************************************
-
     /*
         포인트 선물 받기 내역 조회(가장 최근 것만)
      */
+    @GetMapping("/gift/getlast")
+    public ResponseEntity<ResponseOut<?>> getLastGift(@RequestHeader("Authorization") String token) {
 
-    // 1) 토큰에서 유저아이디 취득
+        GiftLastDto giftLastDto = giftService.getLastGift(token);
 
-    // 2) 선물 테이블에 받는 사람이 1)에서 취득한 유저아이디와 일치하는 데이터 중 등록일이
-    // 가장 최신인 Gift 내용과 point 내용, 상대방 로그인 아이디, 이름 취득
-
-
+        if(giftLastDto == null) {
+            ResponseOut<?> responseOut = ResponseOut.success();
+            return ResponseEntity.ok(responseOut);
+        } else {
+            ResponseOut<?> responseOut = ResponseOut.success(modelMapper.map(giftLastDto, GiftLastOut.class));
+            return ResponseEntity.ok(responseOut);
+        }
+    }
 
     //******************************************************
 

--- a/smilekarina/src/main/java/com/example/smilekarina/gift/vo/GiftLastOut.java
+++ b/smilekarina/src/main/java/com/example/smilekarina/gift/vo/GiftLastOut.java
@@ -1,0 +1,21 @@
+package com.example.smilekarina.gift.vo;
+
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GiftLastOut {
+
+    private Long giftId;
+    private String senderLoginId;
+    private String senderName;
+    private Integer point;
+    private String giftMessage;
+    private LocalDateTime createdDate;
+
+}

--- a/smilekarina/src/main/java/com/example/smilekarina/user/domain/User.java
+++ b/smilekarina/src/main/java/com/example/smilekarina/user/domain/User.java
@@ -44,7 +44,9 @@ public class User extends BaseEntity implements UserDetails {
     @Enumerated(EnumType.STRING)
     @Column(nullable = true, length = 10, name = "roll")
     private Roll roll;
-
+    public String getName() {
+        return userName;
+    }
     public void hashPassword(String password){
         this.password = new BCryptPasswordEncoder().encode(password); // todo: Hashing - spring security
     }


### PR DESCRIPTION
name: 🚀 Pull Request

### 변경 사항 요약
가장 최신의 대기 선물정보 가져오기, 유저 Entity에 getName 추가

### 변경 사유
getUserName을 할 경우, loginId가 불러와지는 문제가 있어서 getName을 쓰도록 추가하였습니다.
point 금액을 알기위해 매번 point테이블을 조회하러 가는 것은 비효율적이여서 Gift테이블에도 point컬럼을 추가하였습니다.

### 변경된 내용
getUserName을 할 경우, loginId가 불러와지는 문제가 있어서 getName을 쓰도록 추가하였습니다.
point 금액을 알기위해 매번 point테이블을 조회하러 가는 것은 비효율적이여서 Gift테이블에도 point컬럼을 추가하였습니다.
가장 최신의 대기 선물정보 가져 오기 처리를 추가하였습니다.

### 관련 이슈
해당 풀 리퀘스트와 관련된 이슈가 있다면 링크를 적어주세요. 예: `#123`

### 테스트 방법
postman으로 실행

### 추가 정보
기타 풀 리퀘스트와 관련된 추가 정보가 있다면 여기에 적어주세요.

### 체크리스트
- [○] 적절한 브랜치로 요청이 제출되었는가?
- [ ] `npm run lint` 를 실행하고 모든 경고와 오류를 해결하였는가?
- [○] 새로운 테스트를 작성하였고, 기존의 테스트를 모두 통과하였는가?
- [ ] 관련 문서를 업데이트하였는가?
