### PR TITLE
포인트내역상단 조회 기능 추가, 포인트비밀번호변경 PATCH로 수정

### DIFF
--- a/smilekarina/src/main/java/com/example/smilekarina/point/application/PointService.java
+++ b/smilekarina/src/main/java/com/example/smilekarina/point/application/PointService.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface PointService {
 
     // 사용가능포인트 조회
-    Integer getUsablePoint(String UUID);
+    Integer getUsablePoint(Long userId);
 
     // 포인트 데이터 등록하기
     Long registerPoint(PointAddDto pointAddDto);

--- a/smilekarina/src/main/java/com/example/smilekarina/point/presentation/PointController.java
+++ b/smilekarina/src/main/java/com/example/smilekarina/point/presentation/PointController.java
@@ -7,6 +7,8 @@ import com.example.smilekarina.point.dto.PointGetDto;
 import com.example.smilekarina.point.vo.PointIn;
 import com.example.smilekarina.point.vo.PointOut;
 import com.example.smilekarina.point.vo.PointPasswordModifyIn;
+import com.example.smilekarina.point.vo.UsablePointOut;
+import com.example.smilekarina.user.application.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -21,11 +23,12 @@ import java.util.List;
 public class PointController {
 
     private final PointService pointService;
+    private final UserService userService;
 
     /*
         포인트 비밀번호 변경
      */
-    @PutMapping("/user/pointpwdChg")
+    @PatchMapping("/user/pointpwdChg")
     public ResponseEntity<?> changePointPassword(@RequestHeader("Authorization") String token,
                                                  @RequestBody PointPasswordModifyIn pointPasswordModifyIn) {
 
@@ -34,22 +37,33 @@ public class PointController {
         return ResponseEntity.ok(responseOut);
     }
 
-//    /*
-//        헤더 포인트 조회
-//     */
-//    @GetMapping("/point/widget/{UUID}")
-//    public ResponseEntity<?> getPointWidget(@PathVariable String UUID) {
-//
-//        // TODO 일단 uuid 받는다고 가정하고 구현함. 나중에 토큰에서 받은값으로 유저정보 얻는 처리로 수정예정
-////        String uuid = "f5f3737a-fabb-4492-a27c-4262bb1c2d51";
-//
-//        // TODO 적립예정 포인트는 사용가능포인트에서 제외 해야함
-//
-//        Integer usablePoint = pointService.getUsablePoint(UUID);
-//        ResponseOut<?> responseOut = ResponseOut.success(usablePoint);
-//        return ResponseEntity.ok(responseOut);
-//    }
-//
+    /*
+        포인트 내역 상단
+     */
+    @GetMapping("/point/usablepoint")
+    public ResponseEntity<?> getPointWidget(@RequestHeader("Authorization") String token) {
+
+        Long userId = userService.getUserIdFromToken(token);
+
+        Integer usablePoint = pointService.getUsablePoint(userId);
+
+        UsablePointOut usablePointOut = UsablePointOut.builder()
+                .totalPoint(usablePoint)
+                .build();
+
+        ResponseOut<?> responseOut = ResponseOut.success(usablePointOut);
+        return ResponseEntity.ok(responseOut);
+    }
+
+
+
+
+
+
+
+
+
+
 //    /*
 //        테스트 데이터 넣기용
 //     */

--- a/smilekarina/src/main/java/com/example/smilekarina/point/vo/UsablePointOut.java
+++ b/smilekarina/src/main/java/com/example/smilekarina/point/vo/UsablePointOut.java
@@ -1,0 +1,12 @@
+package com.example.smilekarina.point.vo;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UsablePointOut {
+
+    private Integer totalPoint;
+
+}


### PR DESCRIPTION
name: 🚀 Pull Request

### 변경 사항 요약
포인트내역상단 조회 기능 추가, 포인트비밀번호변경 PATCH로 수정

### 변경 사유
포인트내역상단 조회 기능 추가, 포인트비밀번호변경 PATCH로 수정

### 변경된 내용
포인트내역상단 조회 기능 추가, 포인트비밀번호변경 PATCH로 수정

### 테스트 방법
postman으로 테스트
1.처음 회원가입한 회원인 경우에는 0이 넘어오는 것 확인
2. 오늘 일반적립, 스마트영수증 적립을 한 경우 사용가능포인트에 포함되지 않는 것을 확인

### 추가 정보
기타 풀 리퀘스트와 관련된 추가 정보가 있다면 여기에 적어주세요.

### 체크리스트
- [○ ] 적절한 브랜치로 요청이 제출되었는가?
- [ ] `npm run lint` 를 실행하고 모든 경고와 오류를 해결하였는가?
- [ ] 새로운 테스트를 작성하였고, 기존의 테스트를 모두 통과하였는가?
- [ ] 관련 문서를 업데이트하였는가?
